### PR TITLE
Add support for redacting tokens via middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,26 +26,16 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 public void ConfigureServices(IServiceCollection services) {
     services
         .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-        .AddJwtBearer(
-            options => {
-                var authentication = this.configuration.GetSection("Authentication");
+        .AddJwtBearer(options => options.TokenValidationParameters = /* ... */)
+}
 
-                options.TokenValidationParameters = new TokenValidationParameters {
-                    ValidIssuers = authentication["Issuer"],
-                    ValidAudience = authentication["ClientId"],
-                    IssuerSigningKey = new SymmetricSecurityKey(
-                        Encoding.UTF8.GetBytes(authentication["ClientSecret"])
-                    )
-                };
-            }
-        );
-
-    // ... other code omitted for brevity
+public void Configure(IApplicationBuilder app, IHostingEnvironment env) {
+    app.UseAuthentication();
+    app.UseMvc();
 }
 ```
 
-Once you install the package, you can add it to your [`JwtBearerOptions`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.jwtbearer.jwtbeareroptions) configuration by calling one of
-the [`JwtBearerOptionsExtensions.AddQueryStringAuthentication`](https://github.com/invio/Invio.Extensions.Authentication.JwtBearer/blob/master/src/Invio.Extensions.Authentication.JwtBearer/JwtBearerOptionsExtensions.cs) extension methods.
+Once you install the package, you can apply it to your [`JwtBearerOptions`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.jwtbearer.jwtbeareroptions) configuration by calling one of the [`AuthenticationBuilderExtensions.AddJwtBearerQueryStringAuthentication`](https://github.com/invio/Invio.Extensions.Authentication.JwtBearer/blob/master/src/Invio.Extensions.Authentication.JwtBearer/AuthenticationBuilderExtensions.cs) extension methods on the JWT Bearer's `AuthenticationBuilder` as well as applying the [`JwtBearerQueryStringMiddleware`](https://github.com/invio/Invio.Extensions.Authentication.JwtBearer/blob/master/src/Invio.Extensions.Authentication.JwtBearer/JwtBearerQueryStringMiddleware.cs) by calling the [`ApplicationBuilderExtensions.UseJwtBearerQueryString`](https://github.com/invio/Invio.Extensions.Authentication.JwtBearer/blob/master/src/Invio.Extensions.Authentication.JwtBearer/ApplicationBuilderExtensions.cs) extension method.
 
 ```cs
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -54,32 +44,33 @@ using Invio.Extensions.Authentication.JwtBearer;
 public void ConfigureServices(IServiceCollection services) {
     services
         .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-        .AddJwtBearer(
-            options => {
-                var authentication = this.configuration.GetSection("Authentication");
+        .AddJwtBearer(options => options.TokenValidationParameters = /* ... */)
 
-                options.TokenValidationParameters = new TokenValidationParameters {
-                    ValidIssuers = authentication["Issuer"],
-                    ValidAudience = authentication["ClientId"],
-                    IssuerSigningKey = new SymmetricSecurityKey(
-                        Encoding.UTF8.GetBytes(authentication["ClientSecret"])
-                    )
-                };
-
-                // Adds "URI Query Parameters" authentication
-
-                options.AddQueryStringAuthentication();
-
-                // Alternatively:
-                //   options.AddQueryStringAuthentication("custom-parameter-name")
+        // This example shows the default options. You can set them to
+        // whatever you like or you can even leave out the lambda altogether.
+        .AddJwtBearerQueryStringAuthentication(
+            (JwtBearerQueryStringOptions options) => {
+                options.QueryStringParameterName = "access_token";
+                options.QueryStringBehavior = QueryStringBehaviors.Redact;
             }
-        );
+        );        
+}
 
-    // ... other code omitted for brevity
+public void Configure(IApplicationBuilder app, IHostingEnvironment env) {
+    app.UseAuthentication();
+    // This should come after authentication but before any logging middleware.
+    app.UseJwtBearerQueryString();
+    app.UseMvc();
 }
 ```
 
-Now you can call your endpoints using URI query parameter authentication. You can test it out like so with [curl](https://en.wikipedia.org/wiki/CURL), or some other tool of your choosing.
+### Configuring the ``
+
+By default, this will enable users to send their JWT bearer tokens using the `"access_token"` query string parameter, and the value of that token will be redacted via the middleware. The string `"(REDACTED)"` is put in the token's place before the [`HttpContext`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.http.httpcontext) representing the user's web request is moved up the pipeline. For more information on how to configure this behavior, see the [`JwtBearerQueryStringOptions`](https://github.com/invio/Invio.Extensions.Authentication.JwtBearer/blob/master/src/Invio.Extensions.Authentication.JwtBearer/JwtBearerQueryStringOptions.cs).
+
+### Wrapping Up
+
+Now you can call your endpoints using URI query parameter authentication. You can test it out like so with [cURL](https://en.wikipedia.org/wiki/CURL), or some other tool of your choosing.
 
 ```
 curl -I https://api.example.com/resource?access_token=eyJhbGciOiJIUzI1NiJ9.e30.bEionjP7X5J_VkgbZPrgfmAbNskfY4eG97AIRGA5kGg

--- a/src/Invio.Extensions.Authentication.JwtBearer/ApplicationBuilderExtensions.cs
+++ b/src/Invio.Extensions.Authentication.JwtBearer/ApplicationBuilderExtensions.cs
@@ -1,0 +1,35 @@
+using System;
+using Microsoft.AspNetCore.Builder;
+
+namespace Invio.Extensions.Authentication.JwtBearer {
+
+    /// <summary>
+    ///   Eases the application of the additonal middlewares necessary to fulfill
+    ///   the <see cref="IJwtBearerQueryStringBehavior" /> defined on the web service's
+    ///   <see cref="JwtBearerQueryStringOptions" />.
+    /// </summary>
+    public static class ApplicationBuilderExtensions {
+
+        /// <summary>
+        ///   Places the <see cref="JwtBearerQueryStringMiddleware" /> into the request
+        ///   pipeline, ensuring the <see cref="IJwtBearerQueryStringBehavior" />
+        ///   defined gets applied.
+        /// </summary>
+        /// <remarks>
+        ///   This should be done after authentication middleware, but before any logging
+        ///   middleware. That will ensure the access token is used to authenticate the user,
+        ///   but nothing else gets to see it unless the behavior was configured to allow it.
+        /// </remarks>
+        public static IApplicationBuilder UseJwtBearerQueryString(
+            this IApplicationBuilder builder) {
+
+            if (builder == null) {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            return builder.UseMiddleware<JwtBearerQueryStringMiddleware>();
+        }
+
+    }
+
+}

--- a/src/Invio.Extensions.Authentication.JwtBearer/AuthenticationBuilderExtensions.cs
+++ b/src/Invio.Extensions.Authentication.JwtBearer/AuthenticationBuilderExtensions.cs
@@ -1,0 +1,69 @@
+using System;
+using Microsoft.AspNetCore.Authentication;
+
+namespace Invio.Extensions.Authentication.JwtBearer {
+
+    /// <summary>
+    ///   Eases the application of the additonal behaviors to a given JWT bearer
+    ///   configuration via its <see cref="AuthenticationBuilder" />.
+    /// </summary>
+    public static class AuthenticationBuilderExtensions {
+
+        /// <summary>
+        ///   Adds authentication of bearer tokens via URI Query Parameters as defined in
+        ///   <see href="https://tools.ietf.org/html/rfc6750#section-2.3">RFC 6750</see>.
+        ///   The name of the query string parameter sought will be the default,
+        ///   "access_token", and the parameter will be redacted via the included
+        ///   <see cref="JwtBearerQueryStringMiddleware" />.
+        /// </summary>
+        /// <param name="builder">
+        ///   The <see cref="AuthenticationBuilder" /> object being used to construct
+        ///   the configuration for a given JWT bearer authentication handler.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="builder" /> is null.
+        /// </exception>
+        public static AuthenticationBuilder AddJwtBearerQueryStringAuthentication(
+            this AuthenticationBuilder builder) {
+
+            return builder.AddJwtBearerQueryStringAuthentication(_ => {});
+        }
+
+        /// <summary>
+        ///   Adds authentication of bearer tokens via URI Query Parameters as defined in
+        ///   <see href="https://tools.ietf.org/html/rfc6750#section-2.3">RFC 6750</see>.
+        ///   The name of the query string parameter sought will be the default,
+        ///   "access_token", and the parameter will be redacted via the included
+        ///   <see cref="JwtBearerQueryStringMiddleware" />, unless otherwise configured
+        ///   via the <paramref name="configureOptions" /> parameter.
+        /// </summary>
+        /// <param name="builder">
+        ///   The <see cref="AuthenticationBuilder" /> object being used to construct
+        ///   the configuration for a given JWT bearer authentication handler.
+        /// </param>
+        /// <param name="configureOptions">
+        ///   An action used to configure how the JWT bearer token should be handled
+        ///   if it is being passed in via the query string.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="builder" /> or
+        ///   <paramref name="configureOptions" /> is null.
+        /// </exception>
+        public static AuthenticationBuilder AddJwtBearerQueryStringAuthentication(
+            this AuthenticationBuilder builder,
+            Action<JwtBearerQueryStringOptions> configureOptions) {
+
+            if (builder == null) {
+                throw new ArgumentNullException(nameof(builder));
+            } else if (configureOptions == null) {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            builder.Services.AddJwtBearerQueryStringAuthentication(configureOptions);
+
+            return builder;
+        }
+
+    }
+
+}

--- a/src/Invio.Extensions.Authentication.JwtBearer/IJwtBearerQueryStringBehavior.cs
+++ b/src/Invio.Extensions.Authentication.JwtBearer/IJwtBearerQueryStringBehavior.cs
@@ -1,0 +1,37 @@
+using System;
+using Microsoft.AspNetCore.Http;
+
+namespace Invio.Extensions.Authentication.JwtBearer {
+
+    /// <summary>
+    ///   Defines how the web service should mutate requests, if at all, in order
+    ///   to manage the query string parameter's
+    /// </summary>
+    public interface IJwtBearerQueryStringBehavior {
+
+        /// <summary>
+        ///   Applies the defined query string mutation behavior to the provided
+        ///   <see cref="HttpContext" />.
+        /// </summary>
+        /// <remarks>
+        ///   Defined in the <see cref="JwtBearerQueryStringOptions" />, this may
+        ///   do something like redact the token, it may move the token into the
+        ///   'Authorization' header using the traditional Bearer authentication
+        ///   scheme, or it may do nothing at all.
+        /// </remarks>
+        /// <param name="context">
+        ///   The <see cref="HttpContext" /> for a given request. The request may or may
+        ///   not be using the query string as a form of authentication.
+        /// </param>
+        /// <param name="options">
+        ///   The <see cref="JwtBearerQueryStringOptions" /> that define how the
+        ///   query string authentication should be managed within this web service.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="context" /> or <paramref name="options" /> is null.
+        /// </exception>
+        void Apply(HttpContext context, JwtBearerQueryStringOptions options);
+
+    }
+
+}

--- a/src/Invio.Extensions.Authentication.JwtBearer/Invio.Extensions.Authentication.JwtBearer.csproj
+++ b/src/Invio.Extensions.Authentication.JwtBearer/Invio.Extensions.Authentication.JwtBearer.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="2.1.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Invio.Extensions.Authentication.JwtBearer/JwtBearerOptionsPostConfiguration.cs
+++ b/src/Invio.Extensions.Authentication.JwtBearer/JwtBearerOptionsPostConfiguration.cs
@@ -1,0 +1,53 @@
+using System;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Options;
+
+namespace Invio.Extensions.Authentication.JwtBearer {
+
+    /// <summary>
+    ///   Updates the <see cref="JwtBearerOptions" /> to enable query string-based
+    ///   authentication with JWT bearer tokens.
+    /// </summary>
+    public sealed class JwtBearerOptionsPostConfiguration : IPostConfigureOptions<JwtBearerOptions> {
+
+        private IOptions<JwtBearerQueryStringOptions> options { get; }
+
+        /// <summary>
+        ///   Instantiates a post configure event handler that will mutate the
+        ///   <see cref="JwtBearerOptions" /> after it has been configured
+        ///   for use by the web service.
+        /// </summary>
+        /// <param name="options">
+        ///   The configuration settings for how the request pipeline will be analyzed
+        ///   and mutated to support query string-based authentication.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="options" /> is null.
+        /// </exception>
+        public JwtBearerOptionsPostConfiguration(IOptions<JwtBearerQueryStringOptions> options) {
+            if (options == null) {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            this.options = options;
+        }
+
+        /// <summary>
+        ///   Mutates the <see cref="JwtBearerOptions" /> such that it will now
+        ///   look for access tokens in the query string, performing authentication
+        ///   with them as it would if the token were presented in the traditional
+        ///   'Authorization' header.
+        /// </summary>
+        public void PostConfigure(string name, JwtBearerOptions bearerOptions) {
+            if (bearerOptions == null) {
+                throw new ArgumentNullException(nameof(bearerOptions));
+            }
+
+            bearerOptions.AddQueryStringAuthentication(
+                this.options.Value.QueryStringParameterName
+            );
+        }
+
+    }
+
+}

--- a/src/Invio.Extensions.Authentication.JwtBearer/JwtBearerQueryStringBehaviorBase.cs
+++ b/src/Invio.Extensions.Authentication.JwtBearer/JwtBearerQueryStringBehaviorBase.cs
@@ -1,0 +1,54 @@
+using System;
+using Microsoft.AspNetCore.Http;
+
+namespace Invio.Extensions.Authentication.JwtBearer {
+
+    /// <summary>
+    ///   A base implementation of the <see cref="IJwtBearerQueryStringBehavior" /> that
+    ///   validates parameters to conform with the interface's requirements that cannot
+    ///   be enforced in the compiler.
+    /// </summary>
+    public abstract class JwtBearerQueryStringBehaviorBase : IJwtBearerQueryStringBehavior {
+
+        /// <summary>
+        ///   Applies the defined query string mutation behavior to the provided
+        ///   <see cref="HttpContext" />.
+        /// </summary>
+        /// <remarks>
+        ///   Defined in the <see cref="JwtBearerQueryStringOptions" />, this may
+        ///   do something like redact the token, it may move the token into the
+        ///   'Authorization' header using the traditional Bearer authentication
+        ///   scheme, or it may do nothing at all.
+        /// </remarks>
+        /// <param name="context">
+        ///   The <see cref="HttpContext" /> for a given request. The request may or may
+        ///   not be using the query string as a form of authentication.
+        /// </param>
+        /// <param name="options">
+        ///   The <see cref="JwtBearerQueryStringOptions" /> that define how the
+        ///   query string authentication should be managed within this web service.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="context" /> or <paramref name="options" /> is null.
+        /// </exception>
+        public void Apply(HttpContext context, JwtBearerQueryStringOptions options) {
+            if (context == null) {
+                throw new ArgumentNullException(nameof(context));
+            } else if (options == null) {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            this.ApplyImpl(context, options);
+        }
+
+        /// <summary>
+        ///   This is the same behavior as the <see cref="Apply" /> method sans the boilerplace
+        ///   <see cref="ArgumentNullException" /> checks.
+        /// </summary>
+        protected abstract void ApplyImpl(
+            HttpContext context,
+            JwtBearerQueryStringOptions options);
+
+    }
+
+}

--- a/src/Invio.Extensions.Authentication.JwtBearer/JwtBearerQueryStringMiddleware.cs
+++ b/src/Invio.Extensions.Authentication.JwtBearer/JwtBearerQueryStringMiddleware.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+
+namespace Invio.Extensions.Authentication.JwtBearer {
+
+    /// <summary>
+    ///   Mutates the <see cref="HttpContext" /> of a given request based upon the behavior
+    ///   defined via the <see cref="JwtBearerQueryStringOptions" />.
+    /// </summary>
+    public sealed class JwtBearerQueryStringMiddleware {
+
+        private RequestDelegate next { get; }
+        private IOptions<JwtBearerQueryStringOptions> options { get; }
+
+        /// <summary>
+        ///   Instantiates a new instance of the <see cref="JwtBearerQueryStringMiddleware" />
+        ///   with the next step in the request pipeline and the
+        ///   <see cref="JwtBearerQueryStringOptions" /> that define how the web request
+        ///   will be mutated in order to perform the desired query string management behavior.
+        /// </summary>
+        /// <param name="next">
+        ///   The next step in the web request pipeline.
+        /// </param>
+        /// <param name="options">
+        ///   The configuration settings for how the request pipeline will be analyzed
+        ///   and mutated to support query string-based authentication.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="next" /> or <paramref name="options" /> is null.
+        /// </exception>
+        public JwtBearerQueryStringMiddleware(
+            RequestDelegate next,
+            IOptions<JwtBearerQueryStringOptions> options) {
+
+            if (next == null) {
+                throw new ArgumentNullException(nameof(next));
+            } else if (options == null) {
+                throw new ArgumentNullException(nameof(options));
+            }
+
+            this.next = next;
+            this.options = options;
+        }
+
+        /// <summary>
+        ///   Runs this step in the pipeline, mutating the <see cref="HttpContext" />
+        ///   in accordance to the configuration defined via the injected
+        ///   <see cref="JwtBearerQueryStringOptions" />.
+        /// </summary>
+        /// <param name="context">
+        ///   The underlying <see cref="HttpContext" /> for the web request being
+        ///   processed by this web service.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="context" /> is null.
+        /// </exception>
+        public Task Invoke(HttpContext context) {
+            if (context == null) {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            this.options.Value.QueryStringBehavior?.Apply(context, options.Value);
+
+            return this.next(context);
+        }
+
+    }
+
+
+}

--- a/src/Invio.Extensions.Authentication.JwtBearer/JwtBearerQueryStringOptions.cs
+++ b/src/Invio.Extensions.Authentication.JwtBearer/JwtBearerQueryStringOptions.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace Invio.Extensions.Authentication.JwtBearer {
+
+    /// <summary>
+    ///   This class defines the configuration of how to query string parameter-based
+    ///   authentication should behave in the service that is consuming this library.
+    /// </summary>
+    public sealed class JwtBearerQueryStringOptions {
+
+        /// <summary>
+        ///   The default query string parameter name sought in the web request's URI.
+        /// </summary>
+        /// <remarks>
+        ///   The name 'access_token' was chosen as it is listed in RFC 6750.
+        /// </remarks>
+        public static string DefaultQueryStringParameterName { get; } = "access_token";
+
+        /// <summary>
+        ///   The name of the query string parameter that will be sought in
+        ///   the web request's URI.
+        /// </summary>
+        public string QueryStringParameterName { get; set; } = DefaultQueryStringParameterName;
+
+        /// <summary>
+        ///   This defines how the query string should be managed in the
+        ///   <see cref="JwtBearerQueryStringMiddleware" />. For example, it may
+        ///   redact the token and inject a placeholder string in its place, or
+        ///   it make leave the token alone entirely.
+        /// </summary>
+        /// <remarks>
+        ///   By default, we redact the query string by swapping its value will be
+        ///   replaced with the word "(REDACTED)". This still lets you know that the
+        ///   user did authenticate via the query string, but token used for
+        ///   authentication is being hidden due to security concerns.
+        /// </remarks>
+        public IJwtBearerQueryStringBehavior QueryStringBehavior { get; set; } =
+            QueryStringBehaviors.Redact;
+
+    }
+
+}

--- a/src/Invio.Extensions.Authentication.JwtBearer/NullJwtBearerQueryStringBehavior.cs
+++ b/src/Invio.Extensions.Authentication.JwtBearer/NullJwtBearerQueryStringBehavior.cs
@@ -1,0 +1,24 @@
+using System;
+using Microsoft.AspNetCore.Http;
+
+namespace Invio.Extensions.Authentication.JwtBearer {
+
+    /// <summary>
+    ///   An implementation of the <see cref="IJwtBearerQueryStringBehavior" /> that
+    ///   performs no mutations to the <see cref="HttpContext" /> of the user's web request.
+    /// </summary>
+    /// <remarks>
+    ///   This can be useful for development or testing scenarios.
+    /// </remarks>
+    public sealed class NullJwtBearerQueryStringBehavior : JwtBearerQueryStringBehaviorBase {
+
+        /// <summary>
+        ///   Performs no mutations to the <see cref="HttpContext" /> of the user's web request.
+        /// </summary>
+        protected override void ApplyImpl(
+            HttpContext context,
+            JwtBearerQueryStringOptions options) {}
+
+    }
+
+}

--- a/src/Invio.Extensions.Authentication.JwtBearer/QueryStringBehaviors.cs
+++ b/src/Invio.Extensions.Authentication.JwtBearer/QueryStringBehaviors.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace Invio.Extensions.Authentication.JwtBearer {
+
+    /// <summary>
+    ///   Various methods and properties that provide an idiomatic way to define
+    ///   the desired <see cref="IJwtBearerQueryStringBehavior" /> for a given
+    ///   instance of <see cref="JwtBearerQueryStringOptions" />.
+    /// </summary>
+    public static class QueryStringBehaviors {
+
+        /// <summary>
+        ///   This behavior will cause the access token to be redacted from the
+        ///   user's web request by replacing it with the string "(REDACTED)".
+        ///   This is the default behavior.
+        /// </summary>
+        public static IJwtBearerQueryStringBehavior Redact { get; }
+
+        /// <summary>
+        ///   This behavior will perform no mutations to the user's web request.
+        /// </summary>
+        /// <remarks>
+        ///   This behavior is not recommended for production environments.
+        ///   However, it may be useful in development and test scenarios.
+        /// </remarks>
+        public static IJwtBearerQueryStringBehavior None { get; }
+
+        static QueryStringBehaviors() {
+            Redact = new RedactJwtBearerQueryStringBehavior();
+            None = new NullJwtBearerQueryStringBehavior();
+        }
+
+        /// <summary>
+        ///   This behavior will cause the access token to be redacted from the
+        ///   user's web request by replacing it with the string provided via
+        ///   the <paramref name="redactedValue" />.
+        /// </summary>
+        /// <param name="redactedValue">
+        ///   The string that will be put in the place of the access token if
+        ///   it is found in the query string.
+        /// </param>
+        public static IJwtBearerQueryStringBehavior RedactWithValue(string redactedValue) {
+            return new RedactJwtBearerQueryStringBehavior(redactedValue);
+        }
+
+    }
+
+}

--- a/src/Invio.Extensions.Authentication.JwtBearer/RedactJwtBearerQueryStringBehavior.cs
+++ b/src/Invio.Extensions.Authentication.JwtBearer/RedactJwtBearerQueryStringBehavior.cs
@@ -1,0 +1,70 @@
+using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Primitives;
+
+namespace Invio.Extensions.Authentication.JwtBearer {
+
+    /// <summary>
+    ///   An implementation of the <see cref="IJwtBearerQueryStringBehavior" /> that
+    ///   removes the access token from the request's query string and replaces it
+    ///   a string value that can be interpreted as the token being redacted.
+    /// </summary>
+    public sealed class RedactJwtBearerQueryStringBehavior : JwtBearerQueryStringBehaviorBase {
+
+        /// <summary>
+        ///   The default value that in place of the access token.
+        /// </summary>
+        public static string DefaultRedactedValue { get; } = "(REDACTED)";
+
+        /// <summary>
+        ///   The value this instance of <see cref="RedactJwtBearerQueryStringBehavior" />
+        ///   will plug as the query string value for every instance where the token's query
+        ///   string parameter name is found.
+        /// </summary>
+        public string RedactedValue { get; }
+
+        /// <summary>
+        ///   Instantiates a new instance of <see cref="RedactJwtBearerQueryStringBehavior" />
+        ///   that will replace all instances of the access token in the query string with
+        ///   the word '(REDACTED)' via the <see cref="JwtBearerQueryStringMiddleware" />.
+        /// </summary>
+        public RedactJwtBearerQueryStringBehavior() : this(DefaultRedactedValue) {}
+
+        /// <summary>
+        ///   Instantiates a new instance of <see cref="RedactJwtBearerQueryStringBehavior" />
+        ///   that will replace all instances of the access token in the query string with
+        ///   the string provided using the <paramref name="redactedValue" /> parameter
+        ///   via the <see cref="JwtBearerQueryStringMiddleware" />.
+        /// </summary>
+        /// <param name="redactedValue">
+        ///   The string that will be used in place of the access token via the
+        ///   <see cref="JwtBearerQueryStringMiddleware" />.
+        /// </param>
+        public RedactJwtBearerQueryStringBehavior(string redactedValue) {
+            this.RedactedValue = redactedValue;
+        }
+
+        /// <summary>
+        ///   Identifies and redacts the access token if it was provided via the query string.
+        /// </summary>
+        protected override void ApplyImpl(
+            HttpContext context,
+            JwtBearerQueryStringOptions options) {
+
+            var request = context.Request;
+            var queryString = QueryHelpers.ParseNullableQuery(request.QueryString.ToString());
+            var parameterName = options.QueryStringParameterName;
+
+            StringValues values;
+
+            if (queryString.TryGetValue(parameterName, out values)) {
+                queryString[parameterName] = new StringValues(this.RedactedValue);
+
+                request.QueryString = QueryString.Create(queryString);
+            }
+        }
+
+    }
+
+}

--- a/src/Invio.Extensions.Authentication.JwtBearer/ServiceCollectionExtensions.cs
+++ b/src/Invio.Extensions.Authentication.JwtBearer/ServiceCollectionExtensions.cs
@@ -1,0 +1,76 @@
+using System;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Invio.Extensions.Authentication.JwtBearer {
+
+    /// <summary>
+    ///   Eases the application of the additonal behaviors to a given JWT bearer
+    ///   configuration via its <see cref="IServiceCollection" />.
+    /// </summary>
+    public static class ServiceCollectionExtensions {
+
+        /// <summary>
+        ///   Adds authentication of bearer tokens via URI Query Parameters as defined in
+        ///   <see href="https://tools.ietf.org/html/rfc6750#section-2.3">RFC 6750</see>.
+        ///   The name of the query string parameter sought will be the default,
+        ///   "access_token", and the parameter will be redacted via the included
+        ///   <see cref="JwtBearerQueryStringMiddleware" />.
+        /// </summary>
+        /// <param name="services">
+        ///   The <see cref="IServiceCollection" /> object being used to construct
+        ///   the configuration for a given JWT bearer authentication handler.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="services" /> is null.
+        /// </exception>
+        public static IServiceCollection AddJwtBearerQueryStringAuthentication(
+            this IServiceCollection services) {
+
+            return services.AddJwtBearerQueryStringAuthentication(_ => {});
+        }
+
+        /// <summary>
+        ///   Adds authentication of bearer tokens via URI Query Parameters as defined in
+        ///   <see href="https://tools.ietf.org/html/rfc6750#section-2.3">RFC 6750</see>.
+        ///   The name of the query string parameter sought will be the default,
+        ///   "access_token", and the parameter will be redacted via the included
+        ///   <see cref="JwtBearerQueryStringMiddleware" />, unless otherwise configured
+        ///   via the <paramref name="configureOptions" /> parameter.
+        /// </summary>
+        /// <param name="services">
+        ///   The <see cref="IServiceCollection" /> object being used to construct
+        ///   the configuration for a given JWT bearer authentication handler.
+        /// </param>
+        /// <param name="configureOptions">
+        ///   An action used to configure how the JWT bearer token should be handled
+        ///   if it is being passed in via the query string.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="services" /> or
+        ///   <paramref name="configureOptions" /> is null.
+        /// </exception>
+        public static IServiceCollection AddJwtBearerQueryStringAuthentication(
+            this IServiceCollection services,
+            Action<JwtBearerQueryStringOptions> configureOptions) {
+
+            if (services == null) {
+                throw new ArgumentNullException(nameof(services));
+            } else if (configureOptions == null) {
+                throw new ArgumentNullException(nameof(configureOptions));
+            }
+
+            services.Configure<JwtBearerQueryStringOptions>(configureOptions);
+            
+            services.AddSingleton<
+                IPostConfigureOptions<JwtBearerOptions>,
+                JwtBearerOptionsPostConfiguration>();
+
+            return services;
+        }
+
+    }
+
+}

--- a/test/Invio.Extensions.Authentication.JwtBearer.Tests/ApplicationBuilderExtensionsTests.cs
+++ b/test/Invio.Extensions.Authentication.JwtBearer.Tests/ApplicationBuilderExtensionsTests.cs
@@ -1,0 +1,59 @@
+using System;
+using Invio.Xunit;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Builder.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Invio.Extensions.Authentication.JwtBearer {
+
+    [UnitTest]
+    public sealed class ApplicationBuilderExtensionsTests {
+
+        [Fact]
+        public static void UseJwtBearerQueryString_NullBuilder() {
+
+            // Arrange
+
+            IApplicationBuilder builder = null;
+
+            // Act
+
+            var exception = Record.Exception(
+                () => builder.UseJwtBearerQueryString()
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        [Fact]
+        public static void UseJwtBearerQueryString_ValidBuilder() {
+
+            // Arrange
+
+            var services = new ServiceCollection();
+
+            services.Configure<JwtBearerQueryStringOptions>(
+                _ => new JwtBearerQueryStringOptions()
+            );
+
+            var builder = new ApplicationBuilder(services.BuildServiceProvider());
+
+            // Act
+
+            var exception = Record.Exception(
+                () => builder.UseJwtBearerQueryString()
+            );
+
+            // Assert
+
+            Assert.Null(exception);
+            Assert.NotNull(builder.Build());
+        }
+
+    }
+
+}

--- a/test/Invio.Extensions.Authentication.JwtBearer.Tests/AuthenticationBuilderExtensionsTests.cs
+++ b/test/Invio.Extensions.Authentication.JwtBearer.Tests/AuthenticationBuilderExtensionsTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Linq;
+using Invio.Xunit;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Invio.Extensions.Authentication.JwtBearer {
+
+    [UnitTest]
+    public sealed class AuthenticationBuilderExtensionsTests {
+
+        [Fact]
+        public static void AddJwtBearerQueryStringAuthentication_NullServices_NoConfigureOptions() {
+
+            // Arrange
+
+            AuthenticationBuilder builder = null;
+
+            // Act
+
+            var exception = Record.Exception(
+                () => builder.AddJwtBearerQueryStringAuthentication()
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        [Fact]
+        public static void AddJwtBearerQueryStringAuthentication_NullServices_WithConfigureOptions() {
+
+            // Arrange
+
+            AuthenticationBuilder builder = null;
+
+            // Act
+
+            var exception = Record.Exception(
+                () => builder.AddJwtBearerQueryStringAuthentication(_ => {})
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        [Fact]
+        public static void AddJwtBearerQueryStringAuthentication_NullConfigureOptions() {
+
+            // Arrange
+
+            var builder = new AuthenticationBuilder(new ServiceCollection());
+
+            // Act
+
+            var exception = Record.Exception(
+                () => builder.AddJwtBearerQueryStringAuthentication(null)
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        [Fact]
+        public static void AddJwtBearerQueryStringAuthentication_AddsPostConfigureJwtBearerOptions() {
+
+            // Arrange
+
+            var builder = new AuthenticationBuilder(new ServiceCollection());
+
+            // Act
+
+            builder.AddJwtBearerQueryStringAuthentication();
+
+            // Assert
+
+            Assert.Contains(
+                typeof(IPostConfigureOptions<JwtBearerOptions>),
+                builder.Services.Select(descriptor => descriptor.ServiceType)
+            );
+        }
+
+        [Fact]
+        public static void AddJwtBearerQueryStringAuthentication_AddsJwtBearerQueryStringOptions() {
+
+            // Arrange
+
+            var builder = new AuthenticationBuilder(new ServiceCollection());
+
+            // Act
+
+            builder.AddJwtBearerQueryStringAuthentication(
+                options => {
+                    options.QueryStringParameterName = "access_token";
+                    options.QueryStringBehavior = QueryStringBehaviors.None;
+                }
+            );
+
+            // Assert
+
+            Assert.Contains(
+                typeof(IConfigureOptions<JwtBearerQueryStringOptions>),
+                builder.Services.Select(descriptor => descriptor.ServiceType)
+            );
+        }
+
+    }
+
+}

--- a/test/Invio.Extensions.Authentication.JwtBearer.Tests/JwtBearerOptionsPostConfigurationTests.cs
+++ b/test/Invio.Extensions.Authentication.JwtBearer.Tests/JwtBearerOptionsPostConfigurationTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Invio.Xunit;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Invio.Extensions.Authentication.JwtBearer {
+
+    [UnitTest]
+    public sealed class JwtBearerOptionsPostConfigurationTests {
+
+        [Fact]
+        public void Constructor_NullOptions() {
+
+            // Act
+
+            var exception = Record.Exception(
+                () => new JwtBearerOptionsPostConfiguration(null)
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("name")]
+        public void PostConfigure_NullBearerOptions(string name) {
+
+            // Arrange
+
+            var configuration = CreatePostConfiguration();
+
+            // Act
+
+            var exception = Record.Exception(
+                () => configuration.PostConfigure(name, null)
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        public static IEnumerable<object[]> PostConfigure_AppliesEventsWrapper_MemberData {
+            get {
+                var tuples = ImmutableList.Create<(string, JwtBearerOptions)>(
+                    ("name", new JwtBearerOptions { Events = null }),
+                    (null, new JwtBearerOptions { Events = new JwtBearerEvents() })
+                );
+
+                return tuples.Select(tuple => new object[] { tuple.Item1, tuple.Item2 });
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(PostConfigure_AppliesEventsWrapper_MemberData))]
+        public void PostConfigure_AppliesEventsWrapper(
+            string name,
+            JwtBearerOptions bearerOptions) {
+
+            // Arrange
+
+            var options = new JwtBearerQueryStringOptions();
+            var configuration = CreatePostConfiguration(options);
+
+            // Act
+
+            configuration.PostConfigure(name, bearerOptions);
+
+            // Assert
+
+            var typed = Assert.IsType<QueryStringJwtBearerEventsWrapper>(bearerOptions.Events);
+            Assert.Equal(options.QueryStringParameterName, typed.QueryStringParameterName);
+        }
+
+        private IPostConfigureOptions<JwtBearerOptions> CreatePostConfiguration(
+            JwtBearerQueryStringOptions options = null) {
+
+            return new JwtBearerOptionsPostConfiguration(
+                Options.Create(options ?? new JwtBearerQueryStringOptions())
+            );
+        }
+
+    }
+
+}

--- a/test/Invio.Extensions.Authentication.JwtBearer.Tests/JwtBearerQueryStringBehaviorBaseTests.cs
+++ b/test/Invio.Extensions.Authentication.JwtBearer.Tests/JwtBearerQueryStringBehaviorBaseTests.cs
@@ -1,0 +1,52 @@
+using System;
+using Invio.Xunit;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Invio.Extensions.Authentication.JwtBearer {
+
+    public abstract class JwtBearerQueryStringBehaviorBaseTests {
+
+        [Fact]
+        public void Apply_NullContext() {
+
+            // Arrange
+
+            var behavior = this.CreateBehavior();
+            var options = new JwtBearerQueryStringOptions();
+
+            // Act
+
+            var exception = Record.Exception(
+                () => behavior.Apply(null, options)
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        [Fact]
+        public void Apply_NullOptions() {
+
+            // Arrange
+
+            var behavior = this.CreateBehavior();
+            var context = new DefaultHttpContext();
+
+            // Act
+
+            var exception = Record.Exception(
+                () => behavior.Apply(context, null)
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        protected abstract IJwtBearerQueryStringBehavior CreateBehavior();
+
+    }
+
+}

--- a/test/Invio.Extensions.Authentication.JwtBearer.Tests/JwtBearerQueryStringMiddlewareTests.cs
+++ b/test/Invio.Extensions.Authentication.JwtBearer.Tests/JwtBearerQueryStringMiddlewareTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Threading.Tasks;
+using Invio.Xunit;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Invio.Extensions.Authentication.JwtBearer {
+
+    [UnitTest]
+    public sealed class JwtBearerQueryStringMiddlewareTests {
+
+        [Fact]
+        public void Constructor_NullRequestDelegate() {
+
+            // Arrange
+
+            var options = Options.Create(new JwtBearerQueryStringOptions());
+
+            // Act
+
+            var exception = Record.Exception(
+                () => new JwtBearerQueryStringMiddleware(null, options)
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        [Fact]
+        public void Constructor_NullOptions() {
+
+            // Arrange
+
+            RequestDelegate next = (context) => Task.CompletedTask;
+
+            // Act
+
+            var exception = Record.Exception(
+                () => new JwtBearerQueryStringMiddleware(next, null)
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        [Fact]
+        public async Task Invoke_NullHttpContext() {
+
+            // Arrange
+
+            var middleware = this.CreateMiddleware();
+
+            // Act
+
+            var exception = await Record.ExceptionAsync(
+                () => middleware.Invoke(null)
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        [Fact]
+        public async Task Invoke_NullQueryStringBehavior() {
+
+            // Arrange
+
+            var middleware = this.CreateMiddleware(
+                options: new JwtBearerQueryStringOptions {
+                    QueryStringBehavior = null
+                }
+            );
+
+            var context = new DefaultHttpContext();
+            var original = context.Request.QueryString.ToString();
+
+            // Act
+
+            await middleware.Invoke(context);
+
+            // Assert
+
+            Assert.Equal(original, context.Request.QueryString.ToString());
+        }
+
+        [Fact]
+        public async Task Invoke_NonNullQueryStringBehavior() {
+
+            // Arrange
+
+            var behavior = new Mock<IJwtBearerQueryStringBehavior>();
+
+            var options = new JwtBearerQueryStringOptions {
+                QueryStringBehavior = behavior.Object
+            };
+
+            var middleware = this.CreateMiddleware(options: options);
+            var context = new DefaultHttpContext();
+
+            // Act
+
+            await middleware.Invoke(context);
+
+            // Assert
+
+            behavior.Verify(
+                mock => mock.Apply(context, options),
+                Times.Once()
+            );
+        }
+
+        private JwtBearerQueryStringMiddleware CreateMiddleware(
+            RequestDelegate next = null,
+            JwtBearerQueryStringOptions options = null) {
+
+            return new JwtBearerQueryStringMiddleware(
+                next ?? (context => Task.CompletedTask),
+                Options.Create(options ?? new JwtBearerQueryStringOptions())
+            );
+        }
+
+    }
+
+}

--- a/test/Invio.Extensions.Authentication.JwtBearer.Tests/NullJwtBearerQueryStringBehaviorTests.cs
+++ b/test/Invio.Extensions.Authentication.JwtBearer.Tests/NullJwtBearerQueryStringBehaviorTests.cs
@@ -1,0 +1,40 @@
+using System;
+using Invio.Xunit;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Invio.Extensions.Authentication.JwtBearer {
+
+    [UnitTest]
+    public sealed class NullJwtBearerQueryStringBehaviorTests :
+        JwtBearerQueryStringBehaviorBaseTests {
+
+        [Fact]
+        public void Apply_QueryStringUnaffected() {
+
+            // Arrange
+
+            var behavior = this.CreateBehavior();
+
+            var context = new DefaultHttpContext();
+            var options = new JwtBearerQueryStringOptions();
+
+            context.Request.QueryString.Add(options.QueryStringParameterName, "Token");
+            var queryString = context.Request.QueryString.ToString();
+
+            // Act
+
+            behavior.Apply(context, options);
+
+            // Assert
+
+            Assert.Equal(queryString, context.Request.QueryString.ToString());
+        }
+
+        protected override IJwtBearerQueryStringBehavior CreateBehavior() {
+            return new NullJwtBearerQueryStringBehavior();
+        }
+
+    }
+
+}

--- a/test/Invio.Extensions.Authentication.JwtBearer.Tests/QueryStringBehaviorsTests.cs
+++ b/test/Invio.Extensions.Authentication.JwtBearer.Tests/QueryStringBehaviorsTests.cs
@@ -1,0 +1,58 @@
+using System;
+using Invio.Xunit;
+using Xunit;
+
+namespace Invio.Extensions.Authentication.JwtBearer {
+
+    [UnitTest]
+    public sealed class QueryStringBehaviorsTests {
+
+        [Fact]
+        public void Redact_UsesDefaultRedactedValue() {
+
+            // Act
+
+            var behavior = QueryStringBehaviors.Redact;
+
+            // Assert
+
+            var typed = Assert.IsType<RedactJwtBearerQueryStringBehavior>(behavior);
+
+            Assert.Equal(
+                RedactJwtBearerQueryStringBehavior.DefaultRedactedValue,
+                typed.RedactedValue
+            );
+        }
+
+        [Fact]
+        public void None_UsesNullBehavior() {
+
+            // Act
+
+            var behavior = QueryStringBehaviors.None;
+
+            // Act
+
+            Assert.IsType<NullJwtBearerQueryStringBehavior>(behavior);
+        }
+
+        [Fact]
+        public void RedactWithValue_UsesProvidedRedactedValue() {
+
+            // Arrange
+
+            const string redactedValue = "Foo";
+
+            // Act
+
+            var behavior = QueryStringBehaviors.RedactWithValue(redactedValue);
+
+            // Assert
+
+            var typed = Assert.IsType<RedactJwtBearerQueryStringBehavior>(behavior);
+            Assert.Equal(redactedValue, typed.RedactedValue);
+        }
+
+    }
+
+}

--- a/test/Invio.Extensions.Authentication.JwtBearer.Tests/RedactJwtBearerQueryStringBehaviorTests.cs
+++ b/test/Invio.Extensions.Authentication.JwtBearer.Tests/RedactJwtBearerQueryStringBehaviorTests.cs
@@ -1,0 +1,132 @@
+using System;
+using Invio.Xunit;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Invio.Extensions.Authentication.JwtBearer {
+
+    [UnitTest]
+    public sealed class RedactJwtBearerQueryStringBehaviorTests : JwtBearerQueryStringBehaviorBaseTests {
+
+        [Fact]
+        public void Apply_QueryStringNotPresent() {
+
+            // Arrange
+
+            var behavior = this.CreateBehavior();
+
+            var context = new DefaultHttpContext();
+            var options = new JwtBearerQueryStringOptions();
+
+            var queryString = new QueryString("?ParameterName=Value1&ParameterName=Value2");
+            context.Request.QueryString = queryString;
+
+            // Act
+
+            behavior.Apply(context, options);
+
+            // Assert
+
+            Assert.Equal(queryString, context.Request.QueryString);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("access_token")]
+        [InlineData("custom-parameter")]
+        public void Apply_QueryStringAppliedOnce(string parameterName) {
+
+            // Arrange
+
+            var behavior = this.CreateBehavior();
+
+            var context = new DefaultHttpContext();
+            var options = new JwtBearerQueryStringOptions {
+                QueryStringParameterName =
+                    parameterName ??
+                    JwtBearerQueryStringOptions.DefaultQueryStringParameterName
+            };
+
+            const string token = "MyToken";
+            var queryString = new QueryString($"?{options.QueryStringParameterName}={token}");
+            context.Request.QueryString = queryString;
+
+            // Act
+
+            behavior.Apply(context, options);
+
+            // Assert
+
+            Assert.Contains(
+                $"{options.QueryStringParameterName}={RedactJwtBearerQueryStringBehavior.DefaultRedactedValue}",
+                context.Request.QueryString.Value
+            );
+
+            Assert.DoesNotContain(token, context.Request.QueryString.Value);
+        }
+
+        [Fact]
+        public void Apply_QueryStringAppliedMultipleTimes() {
+
+            // Arrange
+
+            var behavior = this.CreateBehavior();
+
+            var context = new DefaultHttpContext();
+            var options = new JwtBearerQueryStringOptions();
+
+            const string token = "MyToken";
+            var queryString = new QueryString($"?access_token={token}1&access_token={token}2");
+            context.Request.QueryString = queryString;
+
+            // Act
+
+            behavior.Apply(context, options);
+
+            // Assert
+
+            Assert.Contains(
+                "access_token=" + RedactJwtBearerQueryStringBehavior.DefaultRedactedValue,
+                context.Request.QueryString.Value
+            );
+
+            Assert.DoesNotContain(token, context.Request.QueryString.Value);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void Apply_NullRedactionValuesSupported(string redactedValue) {
+
+            // Arrange
+
+            var behavior = this.CreateBehavior(redactedValue);
+
+            var context = new DefaultHttpContext();
+            var options = new JwtBearerQueryStringOptions();
+
+            const string token = "MyOtherToken";
+            var queryString = new QueryString($"?access_token={token}");
+            context.Request.QueryString = queryString;
+
+            // Act
+
+            behavior.Apply(context, options);
+
+            // Assert
+
+            Assert.Contains("access_token=" + redactedValue, context.Request.QueryString.Value);
+            Assert.DoesNotContain(token, context.Request.QueryString.Value);
+        }
+
+        protected override IJwtBearerQueryStringBehavior CreateBehavior() {
+            return this.CreateBehavior(RedactJwtBearerQueryStringBehavior.DefaultRedactedValue);
+        }
+
+        private IJwtBearerQueryStringBehavior CreateBehavior(string redactedValue) {
+            return new RedactJwtBearerQueryStringBehavior(redactedValue);
+        }
+
+    }
+
+}

--- a/test/Invio.Extensions.Authentication.JwtBearer.Tests/ServiceCollectionExtensionsTests.cs
+++ b/test/Invio.Extensions.Authentication.JwtBearer.Tests/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Linq;
+using Invio.Xunit;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Invio.Extensions.Authentication.JwtBearer {
+
+    [UnitTest]
+    public sealed class ServiceCollectionExtensionsTests {
+
+        [Fact]
+        public static void AddJwtBearerQueryStringAuthentication_NullServices_NoConfigureOptions() {
+
+            // Arrange
+
+            ServiceCollection services = null;
+
+            // Act
+
+            var exception = Record.Exception(
+                () => services.AddJwtBearerQueryStringAuthentication()
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        [Fact]
+        public static void AddJwtBearerQueryStringAuthentication_NullServices_WithConfigureOptions() {
+
+            // Arrange
+
+            ServiceCollection services = null;
+
+            // Act
+
+            var exception = Record.Exception(
+                () => services.AddJwtBearerQueryStringAuthentication(_ => {})
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        [Fact]
+        public static void AddJwtBearerQueryStringAuthentication_NullConfigureOptions() {
+
+            // Arrange
+
+            var services = new ServiceCollection();
+
+            // Act
+
+            var exception = Record.Exception(
+                () => services.AddJwtBearerQueryStringAuthentication(null)
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        [Fact]
+        public static void AddJwtBearerQueryStringAuthentication_AddsPostConfigureJwtBearerOptions() {
+
+            // Arrange
+
+            var services = new ServiceCollection();
+
+            // Act
+
+            services.AddJwtBearerQueryStringAuthentication();
+
+            // Assert
+
+            Assert.Contains(
+                typeof(IPostConfigureOptions<JwtBearerOptions>),
+                services.Select(descriptor => descriptor.ServiceType)
+            );
+        }
+
+        [Fact]
+        public static void AddJwtBearerQueryStringAuthentication_AddsJwtBearerQueryStringOptions() {
+
+            // Arrange
+
+            var services = new ServiceCollection();
+
+            // Act
+
+            services.AddJwtBearerQueryStringAuthentication(
+                options => {
+                    options.QueryStringParameterName = "access_token";
+                    options.QueryStringBehavior = QueryStringBehaviors.None;
+                }
+            );
+
+            // Assert
+
+            Assert.Contains(
+                typeof(IConfigureOptions<JwtBearerQueryStringOptions>),
+                services.Select(descriptor => descriptor.ServiceType)
+            );
+        }
+
+    }
+
+}


### PR DESCRIPTION
We need to be able to redact tokens from the query string so they don't get slurped up by logging tools, so I created a `IJwtBearerQueryStringBehavior` concept and added some middleware that respects it.