### PR TITLE
Fix handling of null & empty query strings in Redact behavior

### DIFF
--- a/src/Invio.Extensions.Authentication.JwtBearer/RedactJwtBearerQueryStringBehavior.cs
+++ b/src/Invio.Extensions.Authentication.JwtBearer/RedactJwtBearerQueryStringBehavior.cs
@@ -52,8 +52,22 @@ namespace Invio.Extensions.Authentication.JwtBearer {
             HttpContext context,
             JwtBearerQueryStringOptions options) {
 
+            if (String.IsNullOrWhiteSpace(options.QueryStringParameterName)) {
+                throw new ArgumentException(
+                    $"The '{nameof(JwtBearerQueryStringOptions.QueryStringParameterName)}' " +
+                    $"property on the '{nameof(options)}' parameter cannot be null or " +
+                    $"whitespace.",
+                    nameof(options)
+                );
+            }
+
             var request = context.Request;
-            var queryString = QueryHelpers.ParseNullableQuery(request.QueryString.ToString());
+
+            if (request.QueryString == null || request.QueryString == QueryString.Empty) {
+                return;
+            }
+
+            var queryString = QueryHelpers.ParseQuery(request.QueryString.Value);
             var parameterName = options.QueryStringParameterName;
 
             StringValues values;

--- a/test/Invio.Extensions.Authentication.JwtBearer.Tests/JwtBearerQueryStringBehaviorBaseTests.cs
+++ b/test/Invio.Extensions.Authentication.JwtBearer.Tests/JwtBearerQueryStringBehaviorBaseTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Invio.Xunit;
 using Microsoft.AspNetCore.Http;
 using Xunit;
@@ -43,6 +44,36 @@ namespace Invio.Extensions.Authentication.JwtBearer {
             // Assert
 
             Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        public static IEnumerable<object[]> Apply_EmptyQueryStringIsIgnored_MemberData {
+            get {
+                yield return new object[] { null };
+                yield return new object[] { new QueryString("?") };
+                yield return new object[] { QueryString.Empty };
+                yield return new object[] { new DefaultHttpContext().Request.QueryString };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(Apply_EmptyQueryStringIsIgnored_MemberData))]
+        public void Apply_EmptyQueryStringIsIgnored(QueryString original) {
+
+            // Arrange
+
+            var behavior = this.CreateBehavior();
+            var context = new DefaultHttpContext();
+            var options = new JwtBearerQueryStringOptions();
+
+            context.Request.QueryString = original;
+
+            // Act
+
+            behavior.Apply(context, options);
+
+            // Assert
+
+            Assert.Equal(original, context.Request.QueryString);
         }
 
         protected abstract IJwtBearerQueryStringBehavior CreateBehavior();

--- a/test/Invio.Extensions.Authentication.JwtBearer.Tests/RedactJwtBearerQueryStringBehaviorTests.cs
+++ b/test/Invio.Extensions.Authentication.JwtBearer.Tests/RedactJwtBearerQueryStringBehaviorTests.cs
@@ -8,6 +8,38 @@ namespace Invio.Extensions.Authentication.JwtBearer {
     [UnitTest]
     public sealed class RedactJwtBearerQueryStringBehaviorTests : JwtBearerQueryStringBehaviorBaseTests {
 
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public void Apply_NullQueryStringParameterNameInOptions(string name) {
+
+            // Arrange
+
+            var behavior = this.CreateBehavior();
+
+            var context = new DefaultHttpContext();
+            var options = new JwtBearerQueryStringOptions { QueryStringParameterName = name };
+            context.Request.QueryString = new QueryString("?access_token=token");
+
+            // Act
+
+            var exception = Record.Exception(
+                () => behavior.Apply(context, options)
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentException>(exception);
+
+            Assert.Equal(
+                $"The 'QueryStringParameterName' property on the " +
+                $"'options' parameter cannot be null or whitespace." +
+                Environment.NewLine + $"Parameter name: options",
+                exception.Message
+            );
+        }
+
         [Fact]
         public void Apply_QueryStringNotPresent() {
 


### PR DESCRIPTION
Noticed the `RedactJwtBearerQueryStringBehavior` was not handling null and empty query strings downstream correctly. This fixes it.