### PR TITLE
Add support for wrapping of inner JwtBearerOptions.EventsType

### DIFF
--- a/src/Invio.Extensions.Authentication.JwtBearer/JwtBearerEventsWrapperBase.cs
+++ b/src/Invio.Extensions.Authentication.JwtBearer/JwtBearerEventsWrapperBase.cs
@@ -15,8 +15,7 @@ namespace Invio.Extensions.Authentication.JwtBearer {
     ///   true wrappers to implement their desired functionality without having
     ///   to provide distracting invocations to the wrapped <see cref="JwtBearerEvents" />.
     /// </remarks>
-    public abstract class JwtBearerEventsWrapperBase : JwtBearerEvents
-    {
+    public abstract class JwtBearerEventsWrapperBase : JwtBearerEvents {
         private JwtBearerEvents inner;
         private readonly Type innerType;
 

--- a/src/Invio.Extensions.Authentication.JwtBearer/JwtBearerEventsWrapperBase.cs
+++ b/src/Invio.Extensions.Authentication.JwtBearer/JwtBearerEventsWrapperBase.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Invio.Extensions.Authentication.JwtBearer {
 
@@ -14,9 +15,10 @@ namespace Invio.Extensions.Authentication.JwtBearer {
     ///   true wrappers to implement their desired functionality without having
     ///   to provide distracting invocations to the wrapped <see cref="JwtBearerEvents" />.
     /// </remarks>
-    public abstract class JwtBearerEventsWrapperBase : JwtBearerEvents {
-
-        private JwtBearerEvents inner { get; }
+    public abstract class JwtBearerEventsWrapperBase : JwtBearerEvents
+    {
+        private JwtBearerEvents inner;
+        private readonly Type innerType;
 
         /// <summary>
         ///   Creates a <see cref="JwtBearerEvents" /> implementation which
@@ -38,18 +40,33 @@ namespace Invio.Extensions.Authentication.JwtBearer {
         }
 
         /// <summary>
+        ///   Creates a <see cref="JwtBearerEvents" /> implementation which
+        ///   does nothing but call the injected wrapped implementation by default.
+        /// </summary>
+        /// <param name="innerType">
+        ///   The base service type that will be resolved from the request services
+        ///   and then invoked after the inheriting wrapper performs its side effects.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="innerType" /> is null.
+        /// </exception>
+        protected JwtBearerEventsWrapperBase(Type innerType) {
+            this.innerType = innerType ?? throw new ArgumentNullException(nameof(innerType));
+        }
+
+        /// <summary>
         ///   Invoked if exceptions are thrown during request processing.
         ///   The exceptions will be re-thrown after this event unless suppressed.
         /// </summary>
         public override Task AuthenticationFailed(AuthenticationFailedContext context) {
-            return inner.AuthenticationFailed(context);
+            return InnerResolved(context).AuthenticationFailed(context);
         }
 
         /// <summary>
         ///   Invoked when a protocol message is first received.
         /// </summary>
         public override Task MessageReceived(MessageReceivedContext context) {
-            return inner.MessageReceived(context);
+            return InnerResolved(context).MessageReceived(context);
         }
 
         /// <summary>
@@ -57,16 +74,19 @@ namespace Invio.Extensions.Authentication.JwtBearer {
         ///   and a ClaimsIdentity has been generated.
         /// </summary>
         public override Task TokenValidated(TokenValidatedContext context) {
-            return inner.TokenValidated(context);
+            return InnerResolved(context).TokenValidated(context);
         }
 
         /// <summary>
         ///   Invoked before a challenge is sent back to the caller.
         /// </summary>
         public override Task Challenge(JwtBearerChallengeContext context) {
-            return inner.Challenge(context);
+            return InnerResolved(context).Challenge(context);
         }
 
+        private JwtBearerEvents InnerResolved(BaseContext<JwtBearerOptions> context) =>
+            inner ??
+            (inner = (JwtBearerEvents)context.HttpContext.RequestServices.GetRequiredService(innerType));
     }
 
 }

--- a/src/Invio.Extensions.Authentication.JwtBearer/JwtBearerOptionsExtensions.cs
+++ b/src/Invio.Extensions.Authentication.JwtBearer/JwtBearerOptionsExtensions.cs
@@ -28,10 +28,18 @@ namespace Invio.Extensions.Authentication.JwtBearer {
                 throw new ArgumentNullException(nameof(options));
             }
 
-            options.Events =
-                new QueryStringJwtBearerEventsWrapper(
-                    options.Events ?? new JwtBearerEvents()
-                );
+            if (options.EventsType == null) {
+                options.Events =
+                    new QueryStringJwtBearerEventsWrapper(
+                        options.Events ?? new JwtBearerEvents()
+                    );
+            } else {
+                options.Events =
+                    new QueryStringJwtBearerEventsWrapper(
+                        options.EventsType
+                    );
+                options.EventsType = null;
+            }
 
             return options;
         }
@@ -61,11 +69,20 @@ namespace Invio.Extensions.Authentication.JwtBearer {
                 throw new ArgumentNullException(nameof(options));
             }
 
-            options.Events =
-                new QueryStringJwtBearerEventsWrapper(
-                    options.Events ?? new JwtBearerEvents(),
-                    queryStringParameterName
-                );
+            if (options.EventsType == null) {
+                options.Events =
+                    new QueryStringJwtBearerEventsWrapper(
+                        options.Events ?? new JwtBearerEvents(),
+                        queryStringParameterName
+                    );
+            } else {
+                options.Events =
+                    new QueryStringJwtBearerEventsWrapper(
+                        options.EventsType,
+                        queryStringParameterName
+                    );
+                options.EventsType = null;
+            }
 
             return options;
         }

--- a/src/Invio.Extensions.Authentication.JwtBearer/QueryStringJwtBearerEventsWrapper.cs
+++ b/src/Invio.Extensions.Authentication.JwtBearer/QueryStringJwtBearerEventsWrapper.cs
@@ -60,6 +60,20 @@ namespace Invio.Extensions.Authentication.JwtBearer {
 
         /// <summary>
         ///   Wraps an instance of <see cref="JwtBearerEvents" /> with a behavior
+        ///   that checks for a token in the query string with a name of "bearer".
+        /// </summary>
+        /// <param name="innerType">
+        ///   A base service type implementation of <see cref="JwtBearerEvents" />
+        ///   that will gain this additional query string inspection behavior.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="innerType" /> is null.
+        /// </exception>
+        public QueryStringJwtBearerEventsWrapper(Type innerType) :
+            this(innerType, DefaultQueryStringParameterName) {}
+
+        /// <summary>
+        ///   Wraps an instance of <see cref="JwtBearerEvents" /> with a behavior
         ///   checks for a token in the query string with a name specified in the
         ///   <paramref name="queryStringParameterName" /> parameter.
         /// </summary>
@@ -81,6 +95,42 @@ namespace Invio.Extensions.Authentication.JwtBearer {
         /// </exception>
         public QueryStringJwtBearerEventsWrapper(JwtBearerEvents inner, string queryStringParameterName) :
             base(inner) {
+
+            if (queryStringParameterName == null) {
+                throw new ArgumentNullException(nameof(queryStringParameterName));
+            } else if (String.IsNullOrWhiteSpace(queryStringParameterName)) {
+                throw new ArgumentException(
+                    $"The '{nameof(queryStringParameterName)}' cannot be null or whitespace.",
+                    nameof(queryStringParameterName)
+                );
+            }
+
+            this.QueryStringParameterName = queryStringParameterName;
+        }
+
+        /// <summary>
+        ///   Wraps an instance of <see cref="JwtBearerEvents" /> with a behavior
+        ///   checks for a token in the query string with a name specified in the
+        ///   <paramref name="queryStringParameterName" /> parameter.
+        /// </summary>
+        /// <param name="innerType">
+        ///   A base service type implementation of <see cref="JwtBearerEvents" />
+        ///   that will gain this additional query string inspection behavior.
+        /// </param>
+        /// <param name="queryStringParameterName">
+        ///   The name of the query string parameter that will be sought from requests
+        ///   in order to extract a token.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   Thrown when <paramref name="innerType" /> or
+        ///   <paramref name="queryStringParameterName" /> is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   Thrown when <paramref name="queryStringParameterName" /> is an invalid name
+        ///   for a query string parameter.
+        /// </exception>
+        public QueryStringJwtBearerEventsWrapper(Type innerType, string queryStringParameterName) :
+            base(innerType) {
 
             if (queryStringParameterName == null) {
                 throw new ArgumentNullException(nameof(queryStringParameterName));

--- a/test/Invio.Extensions.Authentication.JwtBearer.Tests/JwtBearerEventsWrapperBaseTests.cs
+++ b/test/Invio.Extensions.Authentication.JwtBearer.Tests/JwtBearerEventsWrapperBaseTests.cs
@@ -17,6 +17,7 @@ namespace Invio.Extensions.Authentication.JwtBearer {
             var inner = Mock.Of<JwtBearerEvents>();
             var wrapper = this.CreateJwtBearerEvents(inner);
             var context = new DefaultAuthenticationFailedContext();
+            SetupContext(context, inner);
 
             // Act
 
@@ -35,6 +36,7 @@ namespace Invio.Extensions.Authentication.JwtBearer {
             var inner = Mock.Of<JwtBearerEvents>();
             var wrapper = this.CreateJwtBearerEvents(inner);
             var context = new DefaultMessageReceivedContext();
+            SetupContext(context, inner);
 
             // Act
 
@@ -53,6 +55,7 @@ namespace Invio.Extensions.Authentication.JwtBearer {
             var inner = Mock.Of<JwtBearerEvents>();
             var wrapper = this.CreateJwtBearerEvents(inner);
             var context = new DefaultTokenValidatedContext();
+            SetupContext(context, inner);
 
             // Act
 
@@ -71,6 +74,7 @@ namespace Invio.Extensions.Authentication.JwtBearer {
             var inner = Mock.Of<JwtBearerEvents>();
             var wrapper = this.CreateJwtBearerEvents(inner);
             var context = new DefaultJwtBearerChallengeContext();
+            SetupContext(context, inner);
 
             // Act
 
@@ -80,6 +84,9 @@ namespace Invio.Extensions.Authentication.JwtBearer {
 
             Mock.Get(inner).Verify(events => events.Challenge(context));
         }
+
+        protected virtual void SetupContext(BaseContext<JwtBearerOptions> context, 
+            JwtBearerEvents inner) {}
 
         protected abstract JwtBearerEvents CreateJwtBearerEvents(JwtBearerEvents inner);
 

--- a/test/Invio.Extensions.Authentication.JwtBearer.Tests/JwtBearerOptionsExtensionsTests.cs
+++ b/test/Invio.Extensions.Authentication.JwtBearer.Tests/JwtBearerOptionsExtensionsTests.cs
@@ -49,6 +49,30 @@ namespace Invio.Extensions.Authentication.JwtBearer {
         }
 
         [Fact]
+        public static void AddQueryStringAuthentication_DefaultQueryStringParameter_CustomEventsType() {
+
+            // Arrange
+
+            var options = new JwtBearerOptions { EventsType = typeof(JwtBearerEvents) };
+
+            // Act
+
+            options.AddQueryStringAuthentication();
+
+            // Assert
+
+            Assert.NotNull(options.Events);
+            var events = Assert.IsType<QueryStringJwtBearerEventsWrapper>(options.Events);
+
+            Assert.Equal(
+                QueryStringJwtBearerEventsWrapper.DefaultQueryStringParameterName,
+                events.QueryStringParameterName
+            );
+
+            Assert.Null(options.EventsType);
+        }
+
+        [Fact]
         public static void AddQueryStringAuthentication_CustomQueryStringParameter_NullOptions() {
 
             // Arrange
@@ -83,6 +107,26 @@ namespace Invio.Extensions.Authentication.JwtBearer {
             Assert.NotNull(options.Events);
             var events = Assert.IsType<QueryStringJwtBearerEventsWrapper>(options.Events);
             Assert.Equal(queryStringParameterName, events.QueryStringParameterName);
+        }
+
+        [Fact]
+        public static void AddQueryStringAuthentication_CustomQueryStringParameter_CustomEventsType() {
+
+            // Arrange
+
+            var options = new JwtBearerOptions { EventsType = typeof(JwtBearerEvents) };
+            const string queryStringParameterName = "query-string-parameter-name";
+
+            // Act
+
+            options.AddQueryStringAuthentication(queryStringParameterName);
+
+            // Assert
+
+            Assert.NotNull(options.Events);
+            var events = Assert.IsType<QueryStringJwtBearerEventsWrapper>(options.Events);
+            Assert.Equal(queryStringParameterName, events.QueryStringParameterName);
+            Assert.Null(options.EventsType);
         }
 
     }

--- a/test/Invio.Extensions.Authentication.JwtBearer.Tests/JwtBearerOptionsPostConfigurationTests.cs
+++ b/test/Invio.Extensions.Authentication.JwtBearer.Tests/JwtBearerOptionsPostConfigurationTests.cs
@@ -51,7 +51,8 @@ namespace Invio.Extensions.Authentication.JwtBearer {
             get {
                 var tuples = ImmutableList.Create<(string, JwtBearerOptions)>(
                     ("name", new JwtBearerOptions { Events = null }),
-                    (null, new JwtBearerOptions { Events = new JwtBearerEvents() })
+                    (null, new JwtBearerOptions { Events = new JwtBearerEvents() }),
+                    ("name", new JwtBearerOptions { EventsType = typeof(JwtBearerEvents) })
                 );
 
                 return tuples.Select(tuple => new object[] { tuple.Item1, tuple.Item2 });
@@ -77,6 +78,7 @@ namespace Invio.Extensions.Authentication.JwtBearer {
 
             var typed = Assert.IsType<QueryStringJwtBearerEventsWrapper>(bearerOptions.Events);
             Assert.Equal(options.QueryStringParameterName, typed.QueryStringParameterName);
+            Assert.Null(bearerOptions.EventsType);
         }
 
         private IPostConfigureOptions<JwtBearerOptions> CreatePostConfiguration(

--- a/test/Invio.Extensions.Authentication.JwtBearer.Tests/QueryStringJwtBearerEventsTypeWrapperTests.cs
+++ b/test/Invio.Extensions.Authentication.JwtBearer.Tests/QueryStringJwtBearerEventsTypeWrapperTests.cs
@@ -1,24 +1,27 @@
-using System;
+﻿using System;
+using System.Threading.Tasks;
 using Invio.Xunit;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Invio.Extensions.Authentication.JwtBearer {
 
     [UnitTest]
-    public sealed class QueryStringJwtBearerEventsWrapperTests : QueryStringJwtBearerEventsWrapperBaseTests {
+    public sealed class QueryStringJwtBearerEventsTypeWrapperTests : QueryStringJwtBearerEventsWrapperBaseTests {
 
         [Fact]
         public void Constructor_DefaultQueryStringParameterName_NullInner() {
 
             // Arrange
 
-            JwtBearerEvents inner = null;
+            Type innerType = null;
 
             // Act
 
             var exception = Record.Exception(
-                () => new QueryStringJwtBearerEventsWrapper(inner)
+                () => new QueryStringJwtBearerEventsWrapper(innerType)
             );
 
             // Assert
@@ -31,12 +34,12 @@ namespace Invio.Extensions.Authentication.JwtBearer {
 
             // Arrange
 
-            JwtBearerEvents inner = null;
+            Type innerType = null;
 
             // Act
 
             var exception = Record.Exception(
-                () => new QueryStringJwtBearerEventsWrapper(inner, "myCustomQueryStringParameterName")
+                () => new QueryStringJwtBearerEventsWrapper(innerType, "myCustomQueryStringParameterName")
             );
 
             // Assert
@@ -49,12 +52,12 @@ namespace Invio.Extensions.Authentication.JwtBearer {
 
             // Arrange
 
-            var inner = new JwtBearerEvents();
+            var innerType = typeof(JwtBearerEvents);
 
             // Act
 
             var exception = Record.Exception(
-                () => new QueryStringJwtBearerEventsWrapper(inner, null)
+                () => new QueryStringJwtBearerEventsWrapper(innerType, null)
             );
 
             // Assert
@@ -70,12 +73,12 @@ namespace Invio.Extensions.Authentication.JwtBearer {
 
             // Arrange
 
-            var inner = new JwtBearerEvents();
+            var innerType = typeof(JwtBearerEvents);
 
             // Act
 
             var exception = Record.Exception(
-                () => new QueryStringJwtBearerEventsWrapper(inner, queryStringParameterName)
+                () => new QueryStringJwtBearerEventsWrapper(innerType, queryStringParameterName)
             );
 
             // Assert
@@ -89,6 +92,33 @@ namespace Invio.Extensions.Authentication.JwtBearer {
             );
         }
 
+        [Fact]
+        public async Task MessageReceived_NullServiceProvider() {
+
+            // Arrange
+
+            var inner = new JwtBearerEvents();
+            var events = this.CreateJwtBearerEvents(inner);
+            var context = new DefaultMessageReceivedContext();
+            context.HttpContext.RequestServices = null;
+
+            // Act
+
+            var exception = await Record.ExceptionAsync(
+                () => events.MessageReceived(context)
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        protected override void SetupContext(BaseContext<JwtBearerOptions> context, 
+            JwtBearerEvents inner) {
+
+            context.HttpContext.RequestServices = CreateServiceProvider(inner);
+        }
+
         protected override JwtBearerEvents CreateJwtBearerEvents(JwtBearerEvents inner) {
             return this.CreateQueryStringJwtBearerEvents(inner);
         }
@@ -96,13 +126,20 @@ namespace Invio.Extensions.Authentication.JwtBearer {
         protected override QueryStringJwtBearerEventsWrapper CreateQueryStringJwtBearerEvents(
             JwtBearerEvents inner) {
 
-            return new QueryStringJwtBearerEventsWrapper(inner);
+            return new QueryStringJwtBearerEventsWrapper(typeof(JwtBearerEvents));
         }
 
         protected override QueryStringJwtBearerEventsWrapper CreateQueryStringJwtBearerEvents(
             JwtBearerEvents inner, string queryStringParameterName) {
 
-            return new QueryStringJwtBearerEventsWrapper(inner, queryStringParameterName);
+            return new QueryStringJwtBearerEventsWrapper(typeof(JwtBearerEvents), queryStringParameterName);
+        }
+
+        private static IServiceProvider CreateServiceProvider(JwtBearerEvents inner) {
+
+            var services = new ServiceCollection();
+            services.AddSingleton(inner);
+            return services.BuildServiceProvider();
         }
 
     }

--- a/test/Invio.Extensions.Authentication.JwtBearer.Tests/QueryStringJwtBearerEventsWrapperBaseTests.cs
+++ b/test/Invio.Extensions.Authentication.JwtBearer.Tests/QueryStringJwtBearerEventsWrapperBaseTests.cs
@@ -1,0 +1,187 @@
+﻿using System;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Xunit;
+
+namespace Invio.Extensions.Authentication.JwtBearer {
+
+    public abstract class QueryStringJwtBearerEventsWrapperBaseTests : JwtBearerEventsWrapperBaseTests {
+
+        [Fact]
+        public async Task MessageReceived_NullContext() {
+
+            // Arrange
+
+            var inner = new JwtBearerEvents();
+            var events = this.CreateJwtBearerEvents(inner);
+
+            // Act
+
+            var exception = await Record.ExceptionAsync(
+                () => events.MessageReceived(null)
+            );
+
+            // Assert
+
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("?")]
+        [InlineData("?another_token=foo")]
+        public async Task MessageReceived_NoQueryStringParameterName(String queryString) {
+
+            // Arrange
+
+            var inner = Mock.Of<JwtBearerEvents>();
+            var events = this.CreateJwtBearerEvents(inner);
+            var context = new DefaultMessageReceivedContext();
+            context.Request.QueryString = new QueryString(queryString);
+            SetupContext(context, inner);
+
+            // Act
+
+            await events.MessageReceived(context);
+
+            // Assert
+
+            Assert.Null(context.Token);
+            Assert.Null(context.Result);
+            Mock.Get(inner).Verify(e => e.MessageReceived(context));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("=")]
+        [InlineData("=%20")]
+        public async Task MessageReceived_WhiteSpaceToken(String value) {
+
+            // Arrange
+
+            var inner = Mock.Of<JwtBearerEvents>();
+            var events = this.CreateQueryStringJwtBearerEvents(inner);
+            var context = new DefaultMessageReceivedContext();
+            var queryString = $"?{events.QueryStringParameterName}{value}";
+
+            context.Request.QueryString = new QueryString(queryString);
+            SetupContext(context, inner);
+
+            // Act
+
+            await events.MessageReceived(context);
+
+            // Assert
+
+            Assert.Null(context.Token);
+
+            Assert.NotNull(context.Result);
+            Assert.Equal(
+                $"The '{events.QueryStringParameterName}' query string parameter was " +
+                "defined, but a value to represent the token was not included.",
+                context.Result.Failure?.Message
+            );
+
+            Assert.Equal((int)HttpStatusCode.Unauthorized, context.Response.StatusCode);
+            Mock.Get(inner).Verify(e => e.MessageReceived(context));
+        }
+
+        [Fact]
+        public async Task MessageReceived_MoreThanOneToken() {
+
+            // Arrange
+
+            var inner = Mock.Of<JwtBearerEvents>();
+            var events = this.CreateQueryStringJwtBearerEvents(inner);
+            var context = new DefaultMessageReceivedContext();
+            var queryString = $"?{events.QueryStringParameterName}=foo&{events.QueryStringParameterName}=bar";
+
+            context.Request.QueryString = new QueryString(queryString);
+            SetupContext(context, inner);
+
+            // Act
+
+            await events.MessageReceived(context);
+
+            // Assert
+
+            Assert.Null(context.Token);
+
+            Assert.NotNull(context.Result?.Failure);
+            Assert.Equal(
+                $"Only one '{events.QueryStringParameterName}' query string parameter " +
+                "can be defined. However, 2 were included in the request.",
+                context.Result.Failure.Message
+            );
+
+            Assert.Equal((int)HttpStatusCode.Unauthorized, context.Response.StatusCode);
+            Mock.Get(inner).Verify(e => e.MessageReceived(context));
+        }
+
+        [Fact]
+        public async Task MessageReceived_ValidDefaultToken() {
+
+            // Arrange
+
+            var inner = Mock.Of<JwtBearerEvents>();
+            var events = this.CreateQueryStringJwtBearerEvents(inner);
+            var context = new DefaultMessageReceivedContext();
+
+            const string token = "foo";
+            var queryString =
+                $"?{QueryStringJwtBearerEventsWrapper.DefaultQueryStringParameterName}={token}";
+
+            context.Request.QueryString = new QueryString(queryString);
+            SetupContext(context, inner);
+
+            // Act
+
+            await events.MessageReceived(context);
+
+            // Assert
+
+            Assert.Equal(token, context.Token);
+            Assert.Null(context.Result);
+            Mock.Get(inner).Verify(e => e.MessageReceived(context));
+        }
+
+        [Theory]
+        [InlineData("bearer")]
+        [InlineData("id-token")]
+        [InlineData("with space")]
+        public async Task MessageReceived_ValidCustomToken(string customQueryStringParameterName) {
+
+            // Arrange
+
+            var inner = Mock.Of<JwtBearerEvents>();
+            var events = CreateQueryStringJwtBearerEvents(inner, customQueryStringParameterName);
+            var context = new DefaultMessageReceivedContext();
+
+            const string token = "foo";
+            var queryString = $"?{customQueryStringParameterName}={token}";
+
+            context.Request.QueryString = new QueryString(queryString);
+            SetupContext(context, inner);
+
+            // Act
+
+            await events.MessageReceived(context);
+
+            // Assert
+
+            Assert.Equal(token, context.Token);
+            Assert.Null(context.Result);
+            Mock.Get(inner).Verify(e => e.MessageReceived(context));
+        }
+
+        protected abstract QueryStringJwtBearerEventsWrapper CreateQueryStringJwtBearerEvents(
+            JwtBearerEvents inner);
+
+        protected abstract QueryStringJwtBearerEventsWrapper CreateQueryStringJwtBearerEvents(
+            JwtBearerEvents inner, string queryStringParameterName);
+
+    }
+}


### PR DESCRIPTION
- Added a constructor to `JwtBearerEventsWrapperBase` for flexible inner service handling.
- Implemented `InnerResolved` method to resolve inner `JwtBearerEvents` from the service provider.
- Updated `JwtBearerOptionsExtensions` to dynamically set the `Events` property based on `EventsType`.
- Enhanced `QueryStringJwtBearerEventsWrapper` with new constructors and validation checks.
- Introduced new unit tests for `QueryStringJwtBearerEventsTypeWrapper` and `QueryStringJwtBearerEventsWrapperBaseTests`.
- Refactored existing tests to align with the new structure and validate event wrapper behavior.